### PR TITLE
Fix OneToOneField reverse relation handling

### DIFF
--- a/sargilo/integrations/django_integration.py
+++ b/sargilo/integrations/django_integration.py
@@ -117,6 +117,8 @@ class DjangoIntegration(Integration):
         for related_object, related_model in model._meta.get_all_related_objects_with_model():
             if related_object.field.rel.related_name:
                 reverse_relations.append(related_object.field.rel.related_name)
+            elif related_object.field.unique:
+                reverse_relations.append(related_object.var_name)
             else:
                 reverse_relations.append(related_object.var_name + '_set')
         for attribute_name in reverse_relations:  # type: str


### PR DESCRIPTION
The code which determines the reverse relations is currently not working for OneToOneField instances which do not set a specific related_name. In these cases adding `_set` to get the automatically determined reverse name is not the right thing to do and `related_object.var_name` can be left at it is. 

Please have a look if this fix is sufficient.